### PR TITLE
Decode the JSON into a readable object

### DIFF
--- a/GoProStream.py
+++ b/GoProStream.py
@@ -44,7 +44,7 @@ def gopro_live():
 
 	MESSAGE = get_command_msg(KEEP_ALIVE_CMD)
 	URL = "http://10.5.5.9:8080/live/amba.m3u8"
-	response_raw = urllib.request.urlopen('http://10.5.5.9/gp/gpControl').read()
+	response_raw = urllib.request.urlopen('http://10.5.5.9/gp/gpControl').read().decode('utf-8')
 	jsondata=json.loads(response_raw)
 	response=jsondata["info"]["firmware_version"]
 	if "HD4" in response or "HD3.2" in response or "HD5" in response or "HX" in response:


### PR DESCRIPTION
Remedies this issue:
```
Traceback (most recent call last):
  File "goProStream.py", line 114, in <module>
    gopro_live()
  File "goProStream.py", line 48, in gopro_live
    jsondata=json.loads(response_raw)
  File "/usr/lib/python3.4/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```