### PR TITLE
Update to support GoPro HERO7 Black

### DIFF
--- a/GoProStream.py
+++ b/GoProStream.py
@@ -9,7 +9,7 @@
 ## 3. Run this script.
 ##
 ## Supported cameras:
-## GoPro HERO5 (incl. Session), HERO4 (incl. Session), HERO+, HERO3+, HERO3, HERO2 w/ WiFi BacPac.
+## GoPro HERO7 Black, HERO5 (incl. Session), HERO4 (incl. Session), HERO+, HERO3+, HERO3, HERO2 w/ WiFi BacPac.
 ##
 ## That's all! When done, press CTRL+C to quit this application.
 ## 
@@ -65,7 +65,7 @@ def gopro_live():
 		response=jsondata["info"]["firmware_version"]
 	except http.client.BadStatusLine:
 		response = urlopen('http://10.5.5.9/camera/cv').read().decode('utf-8')
-	if "HD4" in response or "HD3.2" in response or "HD5" in response or "HX" in response or "HD6" in response:
+	if "HD4" in response or "HD3.2" in response or "HD5" in response or "HX" in response or "HD6" or "HD7" in response:
 		print("branch HD4")
 		print(jsondata["info"]["model_name"]+"\n"+jsondata["info"]["firmware_version"])
 		##


### PR DESCRIPTION
HERO7 Black (might work for other HERO7 as well) simply identifies itself as HD7. Add that to the detection and live-streaming works fine.