### PR TITLE
Create a local stream for use in e.g. OBS Studio

### DIFF
--- a/GoProStream.py
+++ b/GoProStream.py
@@ -39,6 +39,8 @@ def get_command_msg(id):
 VERBOSE=False
 ## Sends Record command to GoPro Camera, must be in Video mode!
 RECORD=False
+## Converts GoPro camera live stream via FFMPEG to a local source, must be in Video mode!
+STREAM=False
 ##
 ## Saves the feed to a custom location
 SAVE=False
@@ -97,7 +99,10 @@ def gopro_live():
 		if VERBOSE==False:
 			loglevel_verbose = "-loglevel panic"
 		if SAVE == False:
-			subprocess.Popen("ffplay " + loglevel_verbose + " -fflags nobuffer -f:v mpegts -probesize 8192 udp://10.5.5.100:8554", shell=True)
+			if STREAM == True:
+				subprocess.Popen("ffmpeg " + loglevel_verbose + " -fflags nobuffer -f:v mpegts -probesize 8192 -i udp://10.5.5.100:8554 -f mpegts -vcodec copy udp://localhost:10000", shell=True)
+			else:
+				subprocess.Popen("ffplay " + loglevel_verbose + " -fflags nobuffer -f:v mpegts -probesize 8192 udp://10.5.5.100:8554", shell=True)
 		else:
 			if SAVE_FORMAT=="ts":
 				TS_PARAMS = " -acodec copy -vcodec copy "
@@ -107,7 +112,7 @@ def gopro_live():
 			print("Recording locally: " + str(SAVE))
 			print("Recording stored in: " + SAVELOCATION)
 			print("Note: Preview is not available when saving the stream.")
-			subprocess.Popen("ffmpeg -i 'udp://10.5.5.100:8554' -fflags nobuffer -f:v mpegts -probesize 8192 " + TS_PARAMS + SAVELOCATION, shell=True)
+			subprocess.Popen('ffmpeg -i "udp://10.5.5.100:8554" -fflags nobuffer -f:v mpegts -probesize 8192 ' + TS_PARAMS + SAVELOCATION, shell=True)
 		if sys.version_info.major >= 3:
 			MESSAGE = bytes(MESSAGE, "utf-8")
 		print("Press ctrl+C to quit this application.\n")

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Verbose flag for FFmpeg
 
     RECORD=False
 
+Creates a local stream via FFMPEG with minimized lag for use in OBS, camera must be in video mode!
+
+    STREAM=False
+
 Sends a record command to the camera, camera must be in video mode!
 
     SAVE=False

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Verbose flag for FFmpeg
 
     RECORD=False
 
-Creates a local stream via FFMPEG with minimized lag for use in OBS, camera must be in video mode!
+Sends a record command to the camera, camera must be in video mode!
 
     STREAM=False
 
-Sends a record command to the camera, camera must be in video mode!
+Creates a local stream via FFMPEG with minimized lag for use in OBS, camera must be in video mode!
 
     SAVE=False
 


### PR DESCRIPTION
Added new flag STREAM. When set to true it creates a local stream e.g. for use in OBS Studio instead of showing the ffplay preview window.
In OBS Studio add a new Media Source with following parameters to get the GoPro Stream:
Input: udp://@:10000
Input Format mpegts