### PR TITLE
Edit for H18 SW version

### DIFF
--- a/GoProStream.py
+++ b/GoProStream.py
@@ -67,7 +67,7 @@ def gopro_live():
 		response=jsondata["info"]["firmware_version"]
 	except http.client.BadStatusLine:
 		response = urlopen('http://10.5.5.9/camera/cv').read().decode('utf-8')
-	if "HD4" in response or "HD3.2" in response or "HD5" in response or "HX" in response or "HD6" in response or "HD7" in response:
+	if "HD4" in response or "HD3.2" in response or "HD5" in response or "HX" in response or "HD6" in response or "HD7" in response or "H18" in response:
 		print("branch HD4")
 		print(jsondata["info"]["model_name"]+"\n"+jsondata["info"]["firmware_version"])
 		##


### PR DESCRIPTION
https://github.com/KonradIT/GoProStream/issues/67

The script does not support this SW version
Fix for GoPro Hero 7 white H18

```
~$ curl http://10.5.5.9/gp/gpControl | python3 -m json.tool | grep firmware_version
        "firmware_version": "H18.02.02.10.00",

```

```
# python3 GoProStream.py 
branch HD4
HERO7 White
H18.02.02.10.00
UDP target IP: 10.5.5.9
UDP target port: 8554
message: _GPHD_:0:0:2:0.000000

Recording on camera: True
Press ctrl+C to quit this application.

ffmpeg version 6.1.1-3ubuntu5 Copyright (c) 2000-2023 the FFmpeg developers
  built with gcc 13 (Ubuntu 13.2.0-23ubuntu3)
  configuration: --prefix=/usr --extra-version=3ubuntu5 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --disable-omx --enable-gnutls --enable-libaom --enable-libass --enable-libbs2b --enable-libcaca --enable-libcdio --ena
 (...)
```


Keep in mind it might be different for you, since mine is 7 white.
